### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,120 @@
+name: Build
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build-ubuntu-2004:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#configuring-a-build-matrix
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Check Plugin sources
+      uses: actions/checkout@v2
+      with:
+        repository: dougg3/obs-ios-camera-source
+
+    - name: Check OBS sources
+      uses: actions/checkout@v2
+      with:
+        repository: obsproject/obs-studio
+        path: obs-studio
+
+    - name: Install build dependencies
+      run: sudo apt-get install libobs-dev libavcodec-dev
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake ${{runner.workspace}}/obs-ios-camera-source -DLIBOBS_INCLUDE_DIR=${{runner.workspace}}/obs-ios-camera-source/obs-studio/cmake
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: make -j$(nproc)
+    
+    - name: Prepare package
+      working-directory: ${{runner.workspace}}
+      shell: bash
+      run: mkdir -p package/.config/obs-studio/plugins/obs-ios-camera-source/{data/locale,bin/64bit} &&
+        cp build/obs-ios-camera-source.so package/.config/obs-studio/plugins/obs-ios-camera-source/bin/64bit &&
+        cp obs-ios-camera-source/data/locale/* package/.config/obs-studio/plugins/obs-ios-camera-source/data/locale
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: plugin-ubuntu-20.04
+        path: ${{runner.workspace}}/package
+
+  build-ubuntu-1804:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#configuring-a-build-matrix
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Check Plugin sources
+      uses: actions/checkout@v2
+      with:
+        repository: dougg3/obs-ios-camera-source
+
+    - name: Check OBS sources
+      uses: actions/checkout@v2
+      with:
+        repository: obsproject/obs-studio
+        path: obs-studio
+
+    - name: Install build dependencies
+      run: sudo apt-get install libobs-dev libavcodec-dev
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake ${{runner.workspace}}/obs-ios-camera-source -DLIBOBS_INCLUDE_DIR=${{runner.workspace}}/obs-ios-camera-source/obs-studio/cmake
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: make -j$(nproc)
+    
+    - name: Prepare package
+      working-directory: ${{runner.workspace}}
+      shell: bash
+      run: mkdir -p package/.config/obs-studio/plugins/obs-ios-camera-source/{data/locale,bin/64bit} &&
+        cp build/obs-ios-camera-source.so package/.config/obs-studio/plugins/obs-ios-camera-source/bin/64bit &&
+        cp obs-ios-camera-source/data/locale/* package/.config/obs-studio/plugins/obs-ios-camera-source/data/locale
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: plugin-ubuntu-18.04
+        path: ${{runner.workspace}}/package

--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ To use this you use the [accompanying iOS app](https://will.townsend.io/products
 
 ## Downloads
 
-Linux binaries are not provided; instead, compilation and manual installation instructions for Ubuntu 18.04 and 20.04 are supplied below.
+### Ubuntu 20.04 (and possibly other distros) and 18.04
+
+Go to the [actions](https://github.com/dougg3/obs-ios-camera-source/actions) section of this repository and click on the latest workflow that finished successfully. Then download the artifact that corresponds to your version. After downloading, place the zip file in your home directory and run:
+
+```
+unzip plugin-ubuntu-*.zip
+```
+
+You must have the `unzip` package installed for this to work: `sudo apt install unzip`.
 
 ## Building
 


### PR DESCRIPTION
Heyo! First of all, thanks for your work on this. It's really appreciated in these times.

I've been working on adding CI support via Github Actions so the plugin can be automatically built upon pushes to the repo. As far as I could test, the build works correctly and I'm using the output files in my installation of Ubuntu 20.04 without apparent issues. You can see some of the tasks and the final one with the artifacts [here](https://github.com/santicalcagno/obs-ios-camera-source/actions).

I think this can be improved further by making the output artifacts be part of releases, but that's something that I or someone could investigate in the near future. In the meantime, I hope that this can already give some additional value.

Thanks!