### PR TITLE
Link dynamically against OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These instructions are tested on Ubuntu 18.04 and 20.04. For other distros/versi
 - Make sure you have the universe and multiverse repositories enabled so you will have access to FFmpeg.
 - Install OBS Studio using the [instructions on the OBS wiki](https://obsproject.com/wiki/install-instructions#ubuntu-installation).
 - Install prerequisites: `sudo apt install build-essential git cmake libavcodec-dev libssl-dev`
-  - Note: On Fedora, you will need to install both openssl-devel and openssl-static in order for OpenSSL to be detected properly.
+  - Note: On Fedora, the required package for OpenSSL is called openssl-devel.
 - Download the OBS Studio source code somewhere: 
   - `cd ~/Downloads`
   - `git clone https://github.com/obsproject/obs-studio.git`

--- a/deps/libimobiledevice/CMakeLists.txt
+++ b/deps/libimobiledevice/CMakeLists.txt
@@ -1,9 +1,7 @@
 project(libimobiledevice)
 cmake_minimum_required(VERSION 3.2)
 
-set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
-set(OPENSSL_USE_STATIC_LIBS TRUE)
 
 message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
 message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")


### PR DESCRIPTION
libimobiledevice is currently linking statically against OpenSSL and this causes an issue on Arch (see #9). Let's link dynamically instead. That makes more sense.