### PR TITLE
Fix Fedora support, add instructions for Fedora and Arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
 	libavcodec
 	libavutil
 )
+target_link_libraries(obs-ios-camera-source PkgConfig::LIBAV)
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 	set(ARCH 64)

--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ You must have the `unzip` package installed for this to work: `sudo apt install 
 
 ## Building
 
-These instructions are tested on Ubuntu 22.04, 20.04, and 18.04. For other distros/versions, YMMV.
+### Ubuntu 22.04/20.04/18.04
 
 - Make sure you have the universe and multiverse repositories enabled so you will have access to FFmpeg.
-- Install OBS Studio using the [instructions on the OBS wiki](https://obsproject.com/wiki/install-instructions#ubuntu-installation).
+- Install OBS Studio using the [Ubuntu instructions on the OBS wiki](https://obsproject.com/wiki/install-instructions#ubuntu-installation).
   - This should install the headers and CMake files necessary for compiling against libobs. It does on Ubuntu; I can't speak for other distros.
 - Install prerequisites: `sudo apt install build-essential git cmake libavcodec-dev libssl-dev pkg-config`
-  - Note: On Fedora, the required package for OpenSSL is called openssl-devel.
 - Download this plugin source code:
   - `git clone https://github.com/dougg3/obs-ios-camera-source.git`
 - Build the plugin:
@@ -46,6 +45,22 @@ These instructions are tested on Ubuntu 22.04, 20.04, and 18.04. For other distr
   - `cp obs-ios-camera-source.so ~/.config/obs-studio/plugins/obs-ios-camera-source/bin/64bit/`
 
 Note for Ubuntu 18.04 users: this plugin now requires a newer version of CMake than what was bundled originally. Either use the premade binaries, or [upgrade your CMake](https://apt.kitware.com/).
+
+### Fedora 36
+
+- Install OBS Studio using the [Fedora instructions on the OBS wiki](https://obsproject.com/wiki/unofficial-linux-builds#fedora).
+- Install prerequisites: `sudo dnf install obs-studio-devel cmake openssl-devel git make automake gcc gcc-c++ ffmpeg-devel`
+- Follow the same instructions as Ubuntu starting from "Download this plugin source code"
+
+### Arch
+
+- Install OBS Studio using the [Arch instructions on the OBS wiki](https://obsproject.com/wiki/unofficial-linux-builds#arch-linuxmanjaro).
+- Install prerequisites: `sudo pacman -S git make gcc cmake pkg-config`
+- Follow the same instructions as Ubuntu starting from "Download this plugin source code"
+
+### Other distros
+
+- As you can see from the different sections above, the instructions are pretty much the same on all distros. You basically just have to make sure you have FFmpeg, OpenSSL, and libobs development packages installed, along with git, pkg-config, cmake, make, and gcc. CMake should handle everything for you after all the prerequisites are installed.
 
 ## Special thanks
 - [wtsnz](https://github.com/wtsnz) for creating an awesome plugin/app for using your iOS camera in OBS!


### PR DESCRIPTION
I forgot to ensure that FFmpeg was actually being added as a dependency of the plugin. This ensures that necessary include paths are being added when building on Fedora.

Also went ahead and added basic build instructions for Fedora and Arch. It's all the same on everything, you just have to make sure you have all the build dependencies installed.