### PR TITLE
Fix build with newer FFmpeg, sync up with latest upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{matrix.os}}
     steps:
     - name: Check Plugin sources

--- a/src/ffmpeg-decode.c
+++ b/src/ffmpeg-decode.c
@@ -38,8 +38,10 @@ int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id)
         return ret;
     }
 
+#if LIBAVCODEC_VERSION_MAJOR < 60
     if (decode->codec->capabilities & CODEC_CAP_TRUNC)
         decode->decoder->flags |= CODEC_FLAG_TRUNC;
+#endif
 
     decode->decoder->flags |= AV_CODEC_FLAG_LOW_DELAY;
     decode->decoder->flags2 = AV_CODEC_FLAG2_CHUNKS;

--- a/src/obs-ios-camera-plugin.cpp
+++ b/src/obs-ios-camera-plugin.cpp
@@ -22,7 +22,7 @@
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-ios-camera-plugin", "en-US")
 
-#define IOS_CAMERA_PLUGIN_VERSION "2.9.3"
+#define IOS_CAMERA_PLUGIN_VERSION "2.9.4"
 
 extern void RegisterIOSCameraSource();
 

--- a/src/obs-ios-camera-plugin.cpp
+++ b/src/obs-ios-camera-plugin.cpp
@@ -22,7 +22,7 @@
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-ios-camera-plugin", "en-US")
 
-#define IOS_CAMERA_PLUGIN_VERSION "2.9.4"
+#define IOS_CAMERA_PLUGIN_VERSION "2.9.5"
 
 extern void RegisterIOSCameraSource();
 

--- a/src/obs-ios-camera-plugin.cpp
+++ b/src/obs-ios-camera-plugin.cpp
@@ -22,7 +22,7 @@
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-ios-camera-plugin", "en-US")
 
-#define IOS_CAMERA_PLUGIN_VERSION "2.9.5"
+#define IOS_CAMERA_PLUGIN_VERSION "2.9.6"
 
 extern void RegisterIOSCameraSource();
 


### PR DESCRIPTION
CODEC_FLAG_TRUNC and CODEC_CAP_TRUNC were removed from newer versions of FFmpeg. This fixes the build on Fedora 38 for example.

I also noticed that GitHub Actions no longer supports Ubuntu 18.04 so I removed that config.

Finally, I synced up with the upstream version, which seems to just be tweaks to the version number.