### PR TITLE
Fix new obs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{matrix.os}}
     steps:
     - name: Check Plugin sources

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use this you use the [accompanying iOS app](https://obs.camera/) to begin str
 
 ## Downloads
 
-### Ubuntu 22.04 (and possibly other distros), 20.04, and 18.04  
+### Ubuntu 24.04 (and possibly other distros), 22.04, 20.04, and 18.04
 (Confirmed working on Manjaro as of 06 Oct 2022 by [@seffyroff](https://github.com/seffyroff))
 
 Go to the [releases](https://github.com/dougg3/obs-ios-camera-source/releases) section of this repository and download the latest release. After downloading, place the zip file in your home directory and run:
@@ -24,7 +24,7 @@ You must have the `unzip` package installed for this to work: `sudo apt install 
 
 ## Building
 
-### Ubuntu 22.04/20.04/18.04
+### Ubuntu 24.04/22.04/20.04/18.04
 
 - Make sure you have the universe and multiverse repositories enabled so you will have access to FFmpeg.
 - Install OBS Studio using the [Ubuntu instructions on the OBS wiki](https://obsproject.com/wiki/install-instructions#ubuntu-installation).

--- a/src/ffmpeg-decode.c
+++ b/src/ffmpeg-decode.c
@@ -16,7 +16,6 @@
  ******************************************************************************/
 
 #include "ffmpeg-decode.h"
-#include "obs-ffmpeg-compat.h"
 #include <obs-avc.h>
 
 int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id)
@@ -39,8 +38,8 @@ int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id)
     }
 
 #if LIBAVCODEC_VERSION_MAJOR < 60
-    if (decode->codec->capabilities & CODEC_CAP_TRUNC)
-        decode->decoder->flags |= CODEC_FLAG_TRUNC;
+    if (decode->codec->capabilities & AV_CODEC_CAP_TRUNCATED)
+        decode->decoder->flags |= AV_CODEC_FLAG_TRUNCATED;
 #endif
 
     decode->decoder->flags |= AV_CODEC_FLAG_LOW_DELAY;
@@ -148,7 +147,7 @@ static inline enum speaker_layout convert_speaker_layout(uint8_t channels)
 static inline void copy_data(struct ffmpeg_decode *decode, uint8_t *data,
                              size_t size)
 {
-    size_t new_size = size + INPUT_BUFFER_PADDING_SIZE;
+    size_t new_size = size + AV_INPUT_BUFFER_PADDING_SIZE;
 
     if (decode->packet_size < new_size)
     {
@@ -157,7 +156,7 @@ static inline void copy_data(struct ffmpeg_decode *decode, uint8_t *data,
         decode->packet_size = new_size;
     }
 
-    memset(decode->packet_buffer + size, 0, INPUT_BUFFER_PADDING_SIZE);
+    memset(decode->packet_buffer + size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
     memcpy(decode->packet_buffer, data, size);
 }
 

--- a/src/obs-ios-camera-plugin.cpp
+++ b/src/obs-ios-camera-plugin.cpp
@@ -22,7 +22,7 @@
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-ios-camera-plugin", "en-US")
 
-#define IOS_CAMERA_PLUGIN_VERSION "2.9.6"
+#define IOS_CAMERA_PLUGIN_VERSION "2.9.7"
 
 extern void RegisterIOSCameraSource();
 


### PR DESCRIPTION
@dikkedimi pointed out in the comments in #21 that the build seems to be broken. It appears that libobs no longer provides a compatibility header that this plugin was depending on.

Remove the header include, fix things so we don't need it, and officially add Ubuntu 24.04 support. Merge the latest changes from upstream as well, which appears to just be a version number increment.