### PR TITLE
Fix errors and warnings with FFmpeg 7

### DIFF
--- a/src/ffmpeg-decode.c
+++ b/src/ffmpeg-decode.c
@@ -52,8 +52,12 @@ void ffmpeg_decode_free(struct ffmpeg_decode *decode)
 {
     if (decode->decoder)
     {
+#if LIBAVCODEC_VERSION_MAJOR < 61
         avcodec_close(decode->decoder);
         av_free(decode->decoder);
+#else
+        avcodec_free_context(&decode->decoder);
+#endif
     }
 
     if (decode->frame)
@@ -206,7 +210,11 @@ bool ffmpeg_decode_audio(struct ffmpeg_decode *decode,
     audio->samples_per_sec = decode->frame->sample_rate;
     audio->format = convert_sample_format(decode->frame->format);
     audio->speakers =
+#if LIBAVCODEC_VERSION_MAJOR < 61
     convert_speaker_layout((uint8_t)decode->decoder->channels);
+#else
+    convert_speaker_layout((uint8_t)decode->decoder->ch_layout.nb_channels);
+#endif
 
     audio->frames = decode->frame->nb_samples;
 

--- a/src/ffmpeg-decode.h
+++ b/src/ffmpeg-decode.h
@@ -39,7 +39,11 @@ extern "C" {
 struct ffmpeg_decode
 {
 	AVCodecContext *decoder;
+#if LIBAVCODEC_VERSION_MAJOR < 59
 	AVCodec *codec;
+#else
+	const AVCodec *codec;
+#endif
 
 	AVFrame *frame;
 


### PR DESCRIPTION
Fixes #25. This code has been using some deprecated things in FFmpeg for a while now. Fix the build error and also fix a few warnings.

There are still some warnings in the bundled libimobiledevice regarding OpenSSL 3.0. Maybe this code could be updated to pull in the system's version of libimobiledevice in the future instead.