### PR TITLE
Fix cmake 4.0 and GitHub runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
     runs-on: ${{matrix.os}}
     steps:
     - name: Check Plugin sources
@@ -50,7 +50,8 @@ jobs:
         cp obs-ios-camera-source/data/locale/* package/.config/obs-studio/plugins/obs-ios-camera-source/data/locale
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: plugin-${{matrix.os}}
         path: ${{runner.workspace}}/package
+        include-hidden-files: true

--- a/deps/libimobiledevice/CMakeLists.txt
+++ b/deps/libimobiledevice/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(libimobiledevice)
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 find_package(OpenSSL REQUIRED)
 


### PR DESCRIPTION
Fixes #28 

I probably should really update it to also say it's compatible with 4.0, but this works for now.